### PR TITLE
Add invalidation to /project when project is updated

### DIFF
--- a/src/project/controller/item.ts
+++ b/src/project/controller/item.ts
@@ -19,30 +19,34 @@ class Project extends Controller {
   }
 
   async put(ctx: Context) {
-    const project = await projectService.findById(
-      +ctx.params.projectId,
-    );
+    const project = await projectService.findById(+ctx.params.projectId);
 
-    ctx.request.validate<ProjectSchema>('https://tt.badgateway.net/schema/project.json');
+    ctx.request.validate<ProjectSchema>(
+      'https://tt.badgateway.net/schema/project.json'
+    );
     const body = ctx.request.body;
 
     const clientUrl = ctx.request.links.get('client');
     if (clientUrl) {
-      const clientId = (clientUrl.href.split('/').pop());
+      const clientId = clientUrl.href.split('/').pop();
       if (!clientId) {
-        throw new BadRequest('The client link must be in the format /clients/123');
+        throw new BadRequest(
+          'The client link must be in the format /client/123'
+        );
       }
 
       const client = await clientService.findById(+clientId);
       project.client = client;
-
     }
 
     project.name = body.name;
     await projectService.update(project);
 
     ctx.status = 204;
-
+    ctx.response.links.add({
+      rel: 'invalidates',
+      href: '/project',
+    });
   }
 
 


### PR DESCRIPTION
### RE: [Can't create a new Project](https://github.com/badgateway/tt-app/issues/31)

## Summary of changes:
_(see attached image for changes preview)_

- Add invalidation for `/project` when a project updates. Should show updates now when getting projects from collection.

| (BEFORE) After changing project client | (AFTER) After changing project client |
| ----- | ------ |
| ![Screen Shot 2022-10-19 at 4 43 12 PM](https://user-images.githubusercontent.com/52248161/196800123-c294ccff-0cdd-421c-bc90-34f111212dce.png) | ![Screen Shot 2022-10-19 at 4 43 16 PM](https://user-images.githubusercontent.com/52248161/196800147-bda34abe-f7d6-4f34-b205-5db2d2bde0fa.png) |

Prettier changed more than just adding the invalidaiton link, but that's all the changes really. Only noticed after push.

----
Feedback, nitpicks, and/or corrections encouraged. 🤖