### PR TITLE
Handle deleting single timesheet entries before submit. #35

### DIFF
--- a/src/entry/controller/item.ts
+++ b/src/entry/controller/item.ts
@@ -77,26 +77,13 @@ class Entry extends Controller {
       +ctx.params.entryId,
     );
 
-    const projectUrl = ctx.request.links.get('project');
-
-    if (!projectUrl) {
-      throw new BadRequest('A link with rel "project" must be provided');
-    }
-
-    const projectId = (projectUrl.href.split('/').pop());
-    if (!projectId) {
-      throw new BadRequest('The project link must be in the format /projects/123');
-    }
-
     await entryService.deleteEntry(entry);
 
     ctx.response.status = 204;
     ctx.response.links.add({
       rel: 'invalidates',
-      href: `/person/${entry.project.id}/entry`
+      href: `/person/${person.id}/entry`
     });
-
-
   }
 
 }

--- a/src/entry/controller/item.ts
+++ b/src/entry/controller/item.ts
@@ -66,6 +66,40 @@ class Entry extends Controller {
 
   }
 
+  async delete(ctx: Context) {
+
+    const person = await personService.findById(
+      +ctx.params.personId,
+    );
+
+    const entry = await entryService.findById(
+      person,
+      +ctx.params.entryId,
+    );
+
+    const projectUrl = ctx.request.links.get('project');
+
+    if (!projectUrl) {
+      throw new BadRequest('A link with rel "project" must be provided');
+    }
+
+    const projectId = (projectUrl.href.split('/').pop());
+    if (!projectId) {
+      throw new BadRequest('The project link must be in the format /projects/123');
+    }
+
+    const project = await projectService.findById(+projectId);
+
+    await entryService.deleteEntry(entry, project);
+
+    ctx.response.status = 204;
+    // ctx.response.links.add({
+    //   rel: 'invalidates',
+    //   href: `/org/${org.id}/category`
+    // });
+
+  }
+
 }
 
 export default new Entry();

--- a/src/entry/controller/item.ts
+++ b/src/entry/controller/item.ts
@@ -88,15 +88,14 @@ class Entry extends Controller {
       throw new BadRequest('The project link must be in the format /projects/123');
     }
 
-    const project = await projectService.findById(+projectId);
-
-    await entryService.deleteEntry(entry, project);
+    await entryService.deleteEntry(entry);
 
     ctx.response.status = 204;
-    // ctx.response.links.add({
-    //   rel: 'invalidates',
-    //   href: `/org/${org.id}/category`
-    // });
+    ctx.response.links.add({
+      rel: 'invalidates',
+      href: `/person/${entry.project.id}/entry`
+    });
+
 
   }
 

--- a/src/entry/service.ts
+++ b/src/entry/service.ts
@@ -161,6 +161,10 @@ export async function update(entry: Entry): Promise<void> {
 
 }
 
+export async function deleteEntry(entry: Entry){
+  
+}
+
 function mapRecord(input: EntriesRecord, project: Project, person: Person): Entry {
 
   return {

--- a/src/entry/service.ts
+++ b/src/entry/service.ts
@@ -161,9 +161,9 @@ export async function update(entry: Entry): Promise<void> {
 
 }
 
-export async function deleteEntry(entry: Entry, project: Project): Promise<void>{
+export async function deleteEntry(entry: Entry): Promise<void>{
   await knex('entries')
-    .where({project_id: project.id})
+    .where({project_id: entry.project.id})
     .where({id: entry.id})
     .del();
 }

--- a/src/entry/service.ts
+++ b/src/entry/service.ts
@@ -161,8 +161,11 @@ export async function update(entry: Entry): Promise<void> {
 
 }
 
-export async function deleteEntry(entry: Entry){
-  
+export async function deleteEntry(entry: Entry, project: Project): Promise<void>{
+  await knex('entries')
+    .where({project_id: project.id})
+    .where({id: entry.id})
+    .del();
 }
 
 function mapRecord(input: EntriesRecord, project: Project, person: Person): Entry {


### PR DESCRIPTION
Resolves #35 

## Changes

- added a new HTTP method `DELETE` to` /entry/controller/item.ts`
- added a new `Entry` service called `deleteEntry()`
- invalidating the entry collection upon deletion 