### PR TITLE
When a 'client' gets created, mark the current user as 'owner'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@curveball/browser": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.4.tgz",
-      "integrity": "sha512-ty1HcA7Z/uYWX/l+FL4UOvCfVwS91tBDB8ZR9jxSg787nsuh9BubWtKbejufGsKetbNzYpbIlV4i34GgC9JYPg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.7.tgz",
+      "integrity": "sha512-H/qd8L60SQW//0svb8Lsfb5UH9FC8lflqxaFW6LdCuizXyN5IKZ9wuJypA7oNWZmyX4cJlPvyJ4HeIn+4XCBzg==",
       "dependencies": {
         "@curveball/static": "^0.3.0",
         "csv-parse": "^5.1.0",
@@ -2940,9 +2940,9 @@
       "requires": {}
     },
     "@curveball/browser": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.4.tgz",
-      "integrity": "sha512-ty1HcA7Z/uYWX/l+FL4UOvCfVwS91tBDB8ZR9jxSg787nsuh9BubWtKbejufGsKetbNzYpbIlV4i34GgC9JYPg==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@curveball/browser/-/browser-0.19.7.tgz",
+      "integrity": "sha512-H/qd8L60SQW//0svb8Lsfb5UH9FC8lflqxaFW6LdCuizXyN5IKZ9wuJypA7oNWZmyX4cJlPvyJ4HeIn+4XCBzg==",
       "requires": {
         "@curveball/static": "^0.3.0",
         "csv-parse": "^5.1.0",

--- a/src/a12n.ts
+++ b/src/a12n.ts
@@ -3,11 +3,11 @@ import { LinkNotFound } from 'ketting';
 
 
 
-export async function addUserPrivilege(principal: string, privilege: string, resource: string): Promise<void> {
+export async function addUserPrivilege(principal: string|URL, privilege: string, resource: string|URL): Promise<void> {
   let userPrivilegesRes;
 
   try {
-    userPrivilegesRes = await ketting.go(principal).follow('privileges');
+    userPrivilegesRes = await ketting.go(principal.toString()).follow('privileges');
   } catch (err) {
     if (err instanceof LinkNotFound) {
       throw new Error('Link with "privileges" is not found on the user resource. This could mean that the tt-api APP in a12n-server does not have the *admin" privilege');
@@ -22,6 +22,6 @@ export async function addUserPrivilege(principal: string, privilege: string, res
   await userPrivilegesState.action('add').submit({
     action: 'add',
     privilege,
-    resource
+    resource: resource.toString()
   });
 }

--- a/src/a12n.ts
+++ b/src/a12n.ts
@@ -3,11 +3,11 @@ import { LinkNotFound } from 'ketting';
 
 
 
-export async function addUserPrivilege(authenticatedAsHref: string, origin: string, resource: any): Promise<void> {
+export async function addUserPrivilege(principal: string, privilege: string, resource: string, origin: string): Promise<void> {
   let userPrivilegesRes;
 
   try {
-    userPrivilegesRes = await ketting.go(authenticatedAsHref).follow('privileges');
+    userPrivilegesRes = await ketting.go(principal).follow('privileges');
   } catch (err) {
     if (err instanceof LinkNotFound) {
       throw new Error('Link with "privileges" is not found on the user resource. This could mean that the tt-api APP in a12n-server does not have the *admin" privilege');
@@ -21,7 +21,7 @@ export async function addUserPrivilege(authenticatedAsHref: string, origin: stri
   }
   await userPrivilegesState.action('add').submit({
     action: 'add',
-    privilege: 'owner',
-    resource: new URL(resource.href, origin).toString()
+    privilege,
+    resource: new URL(resource, origin).toString()
   });
 }

--- a/src/a12n.ts
+++ b/src/a12n.ts
@@ -3,7 +3,7 @@ import { LinkNotFound } from 'ketting';
 
 
 
-export async function addUserPrivilege(principal: string, privilege: string, resource: string, origin: string): Promise<void> {
+export async function addUserPrivilege(principal: string, privilege: string, resource: string): Promise<void> {
   let userPrivilegesRes;
 
   try {
@@ -22,6 +22,6 @@ export async function addUserPrivilege(principal: string, privilege: string, res
   await userPrivilegesState.action('add').submit({
     action: 'add',
     privilege,
-    resource: new URL(resource, origin).toString()
+    resource
   });
 }

--- a/src/a12n.ts
+++ b/src/a12n.ts
@@ -1,0 +1,27 @@
+import ketting from './ketting';
+import { LinkNotFound } from 'ketting';
+
+
+
+export async function addUserPrivilege(authenticatedAsHref: string, origin: string, resource: any): Promise<void> {
+  let userPrivilegesRes;
+
+  try {
+    userPrivilegesRes = await ketting.go(authenticatedAsHref).follow('privileges');
+  } catch (err) {
+    if (err instanceof LinkNotFound) {
+      throw new Error('Link with "privileges" is not found on the user resource. This could mean that the tt-api APP in a12n-server does not have the *admin" privilege');
+    }
+    throw err;
+  }
+
+  const userPrivilegesState = await userPrivilegesRes.get();
+  if (!userPrivilegesState.hasAction('add')) {
+    throw new Error('The privileges resource on a12nserver does not have an \'add\' action. You likely need to update your a12n-server for this to work');
+  }
+  await userPrivilegesState.action('add').submit({
+    action: 'add',
+    privilege: 'owner',
+    resource: new URL(resource.href, origin).toString()
+  });
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,6 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+
 import accessLog from '@curveball/accesslog';
 import bodyParser from '@curveball/bodyparser';
 import browser from '@curveball/browser';
@@ -9,14 +12,10 @@ import cors from '@curveball/cors';
 import session from '@curveball/session';
 import browserToBearer from '@curveball/browser-to-bearer';
 import oauth2 from '@curveball/oauth2';
-import { OAuth2Client } from '@badgateway/oauth2-client';
+import oauth2Client from './oauth2';
 
 import * as path from 'path';
-import * as dotenv from 'dotenv';
-
 import routes from './routes';
-
-dotenv.config();
 
 const app = new Application();
 
@@ -60,20 +59,16 @@ app.use(validator({
   schemaPath: path.join(__dirname, '../node_modules/@badgateway/tt-types/schema')
 }));
 
-// a12n setup
-const client = new OAuth2Client({
-  server: process.env.AUTH_API_URI,
-  clientId: process.env.OAUTH2_CLIENT_ID || 'tt-api',
-  clientSecret: process.env.OAUTH2_CLIENT_SECRET,
-});
 
-app.use(browserToBearer({client}));
+app.use(browserToBearer({
+  client: oauth2Client,
+}));
 
 app.use(oauth2({
   publicPrefixes: [
     '/health',
   ],
-  client,
+  client: oauth2Client,
 }));
 
 

--- a/src/client/controller/collection.ts
+++ b/src/client/controller/collection.ts
@@ -27,11 +27,10 @@ class ClientCollection extends Controller {
       name: body.name,
     });
 
-    const resource = new URL(client.href, ctx.request.origin).toString(),
     await addUserPrivilege(
       ctx.state.oauth2._links['authenticated-as'].href,
       'owner',
-      resource
+      new URL(client.href, ctx.request.origin),
     );
 
     ctx.status = 201;

--- a/src/client/controller/collection.ts
+++ b/src/client/controller/collection.ts
@@ -27,11 +27,11 @@ class ClientCollection extends Controller {
       name: body.name,
     });
 
+    const resource = new URL(client.href, ctx.request.origin).toString(),
     await addUserPrivilege(
       ctx.state.oauth2._links['authenticated-as'].href,
       'owner',
-      client.href,
-      ctx.request.origin
+      resource
     );
 
     ctx.status = 201;

--- a/src/client/controller/collection.ts
+++ b/src/client/controller/collection.ts
@@ -27,10 +27,12 @@ class ClientCollection extends Controller {
       name: body.name,
     });
 
-    addUserPrivilege(
+    await addUserPrivilege(
       ctx.state.oauth2._links['authenticated-as'].href,
-      ctx.request.origin,
-      client);
+      'owner',
+      client.href,
+      ctx.request.origin
+    );
 
     ctx.status = 201;
     ctx.response.headers.set('Location', client.href);

--- a/src/client/controller/collection.ts
+++ b/src/client/controller/collection.ts
@@ -3,8 +3,10 @@ import { Context } from '@curveball/core';
 
 import * as hal from '../formats/hal';
 import * as clientService from '../service';
+import ketting from '../../ketting';
 
 import { ClientNew as ClientNewSchema } from '@badgateway/tt-types';
+import { LinkNotFound } from 'ketting';
 
 class ClientCollection extends Controller {
 
@@ -23,6 +25,31 @@ class ClientCollection extends Controller {
     const body = ctx.request.body;
     const client = await clientService.create({
       name: body.name,
+    });
+
+    let userPrivilegesRes;
+
+    try {
+
+      userPrivilegesRes = await ketting.go(
+        ctx.state.oauth2._links['authenticated-as'].href
+      ).follow('privileges');
+
+    } catch (err) {
+      if (err instanceof LinkNotFound) {
+        throw new Error('Link with "privileges" is not found on the user resource. This could mean that the tt-api APP in a12n-server does not have the *admin" privilege');
+      }
+      throw err;
+    }
+
+    const userPrivilegesState = await userPrivilegesRes.get();
+    if (!userPrivilegesState.hasAction('add')) {
+      throw new Error('The privileges resource on a12nserver does not have an \'add\' action. You likely need to update your a12n-server for this to work');
+    }
+    await userPrivilegesState.action('add').submit({
+      action: 'add',
+      privilege: 'owner',
+      resource: new URL(client.href, ctx.request.origin).toString()
     });
 
     ctx.status = 201;

--- a/src/client/controller/collection.ts
+++ b/src/client/controller/collection.ts
@@ -5,6 +5,7 @@ import * as hal from '../formats/hal';
 import * as clientService from '../service';
 
 import { ClientNew as ClientNewSchema } from '@badgateway/tt-types';
+import { addUserPrivilege } from '../../a12n';
 
 
 class ClientCollection extends Controller {
@@ -26,7 +27,10 @@ class ClientCollection extends Controller {
       name: body.name,
     });
 
-    clientService.addUserPrivilege(ctx, client);
+    addUserPrivilege(
+      ctx.state.oauth2._links['authenticated-as'].href,
+      ctx.request.origin,
+      client);
 
     ctx.status = 201;
     ctx.response.headers.set('Location', client.href);

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -1,7 +1,10 @@
 import { Client, NewClient } from '../types';
 import { NotFound } from '@curveball/http-errors';
+import { Context } from '@curveball/core';
 import knex from '../db';
 import { ClientsRecord } from 'knex/types/tables';
+import ketting from '../ketting';
+import { LinkNotFound } from 'ketting';
 
 export async function findAll(): Promise<Client[]> {
 
@@ -62,4 +65,31 @@ function mapRecord(input: ClientsRecord): Client {
     modifiedAt: input.modified_at
   };
 
+}
+
+export async function addUserPrivilege(ctx: Context, client: Client): Promise<void> {
+  let userPrivilegesRes;
+
+  try {
+
+    userPrivilegesRes = await ketting.go(
+      ctx.state.oauth2._links['authenticated-as'].href
+    ).follow('privileges');
+
+  } catch (err) {
+    if (err instanceof LinkNotFound) {
+      throw new Error('Link with "privileges" is not found on the user resource. This could mean that the tt-api APP in a12n-server does not have the *admin" privilege');
+    }
+    throw err;
+  }
+
+  const userPrivilegesState = await userPrivilegesRes.get();
+  if (!userPrivilegesState.hasAction('add')) {
+    throw new Error('The privileges resource on a12nserver does not have an \'add\' action. You likely need to update your a12n-server for this to work');
+  }
+  await userPrivilegesState.action('add').submit({
+    action: 'add',
+    privilege: 'owner',
+    resource: new URL(client.href, ctx.request.origin).toString()
+  });
 }

--- a/src/client/service.ts
+++ b/src/client/service.ts
@@ -1,10 +1,8 @@
 import { Client, NewClient } from '../types';
 import { NotFound } from '@curveball/http-errors';
-import { Context } from '@curveball/core';
 import knex from '../db';
 import { ClientsRecord } from 'knex/types/tables';
-import ketting from '../ketting';
-import { LinkNotFound } from 'ketting';
+
 
 export async function findAll(): Promise<Client[]> {
 
@@ -67,29 +65,3 @@ function mapRecord(input: ClientsRecord): Client {
 
 }
 
-export async function addUserPrivilege(ctx: Context, client: Client): Promise<void> {
-  let userPrivilegesRes;
-
-  try {
-
-    userPrivilegesRes = await ketting.go(
-      ctx.state.oauth2._links['authenticated-as'].href
-    ).follow('privileges');
-
-  } catch (err) {
-    if (err instanceof LinkNotFound) {
-      throw new Error('Link with "privileges" is not found on the user resource. This could mean that the tt-api APP in a12n-server does not have the *admin" privilege');
-    }
-    throw err;
-  }
-
-  const userPrivilegesState = await userPrivilegesRes.get();
-  if (!userPrivilegesState.hasAction('add')) {
-    throw new Error('The privileges resource on a12nserver does not have an \'add\' action. You likely need to update your a12n-server for this to work');
-  }
-  await userPrivilegesState.action('add').submit({
-    action: 'add',
-    privilege: 'owner',
-    resource: new URL(client.href, ctx.request.origin).toString()
-  });
-}

--- a/src/ketting.ts
+++ b/src/ketting.ts
@@ -1,0 +1,17 @@
+import { Client } from 'ketting';
+import oauth2Client from './oauth2';
+import { OAuth2Fetch } from '@badgateway/oauth2-client';
+
+console.debug('🔗 Setting up Ketting client');
+const client = new Client(process.env.AUTH_API_URI!);
+
+const oauth2FetchWrapper = new OAuth2Fetch({
+  client: oauth2Client,
+  getNewToken: () => {
+    return oauth2Client.clientCredentials();
+  }
+});
+
+client.use(oauth2FetchWrapper.mw());
+
+export default client;

--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -1,7 +1,5 @@
 import { OAuth2Client } from '@badgateway/oauth2-client';
 
-console.log('Loading oauth2 client');
-
 // a12n setup
 export default new OAuth2Client({
   server: process.env.AUTH_API_URI,

--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -1,0 +1,10 @@
+import { OAuth2Client } from '@badgateway/oauth2-client';
+
+console.log('Loading oauth2 client');
+
+// a12n setup
+export default new OAuth2Client({
+  server: process.env.AUTH_API_URI,
+  clientId: process.env.OAUTH2_CLIENT_ID || 'tt-api',
+  clientSecret: process.env.OAUTH2_CLIENT_SECRET,
+});


### PR DESCRIPTION
This is a tiny first step towards ACL support. When a new 'client' gets created in tt-api, the controller will now automatically add mark the current principal(user) as the owner.

This works, but needs some refactoring because it's a lot of code for a controller and we really wanna centralize it.

Part of #14 