### PR TITLE
Invalidate entry's sheet collection when delete

### DIFF
--- a/src/entry/controller/item.ts
+++ b/src/entry/controller/item.ts
@@ -72,12 +72,12 @@ class Entry extends Controller {
       +ctx.params.personId,
     );
 
-    const entryDate = DateTime.fromISO(entry.date);
-
     const entry = await entryService.findById(
       person,
       +ctx.params.entryId,
     );
+
+    const entryDate = DateTime.fromISO(entry.date);
 
     await entryService.deleteEntry(entry);
 

--- a/src/entry/controller/item.ts
+++ b/src/entry/controller/item.ts
@@ -7,27 +7,38 @@ import * as personService from '../../person/service';
 import * as projectService from '../../project/service';
 import * as hal from '../formats/hal';
 import {DateTime} from 'luxon';
-import {Entry as EntrySchema} from '@badgateway/tt-types';
+import { Entry as EntrySchema } from '@badgateway/tt-types';
 
 class Entry extends Controller {
+
   async get(ctx: Context) {
+
     ctx.response.type = 'application/hal+json';
 
-    const person = await personService.findById(+ctx.params.personId);
+    const person = await personService.findById(
+      +ctx.params.personId,
+    );
 
     ctx.response.body = hal.item(
-      await entryService.findById(person, +ctx.params.entryId)
+      await entryService.findById(
+        person,
+        +ctx.params.entryId,
+      )
     );
   }
 
   async put(ctx: Context) {
-    ctx.request.validate<EntrySchema>(
-      'https://tt.badgateway.net/schema/entry.json'
+
+    ctx.request.validate<EntrySchema>('https://tt.badgateway.net/schema/entry.json');
+
+    const person = await personService.findById(
+      +ctx.params.personId,
     );
 
-    const person = await personService.findById(+ctx.params.personId);
-
-    const entry = await entryService.findById(person, +ctx.params.entryId);
+    const entry = await entryService.findById(
+      person,
+      +ctx.params.entryId,
+    );
 
     const body = ctx.request.body;
 
@@ -37,11 +48,9 @@ class Entry extends Controller {
       throw new BadRequest('A link with rel "project" must be provided');
     }
 
-    const projectId = projectUrl.href.split('/').pop();
+    const projectId = (projectUrl.href.split('/').pop());
     if (!projectId) {
-      throw new BadRequest(
-        'The project link must be in the format /projects/123'
-      );
+      throw new BadRequest('The project link must be in the format /projects/123');
     }
 
     const project = await projectService.findById(+projectId);
@@ -54,27 +63,35 @@ class Entry extends Controller {
 
     await entryService.update(entry);
     ctx.status = 204;
+
   }
 
   async delete(ctx: Context) {
-    const person = await personService.findById(+ctx.params.personId);
 
-    const entry = await entryService.findById(person, +ctx.params.entryId);
+    const person = await personService.findById(
+      +ctx.params.personId,
+    );
 
     const entryDate = DateTime.fromISO(entry.date);
+
+    const entry = await entryService.findById(
+      person,
+      +ctx.params.entryId,
+    );
 
     await entryService.deleteEntry(entry);
 
     ctx.response.status = 204;
     ctx.response.links.add({
       rel: 'invalidates',
-      href: `/person/${person.id}/entry`,
+      href: `/person/${person.id}/entry`
     });
     ctx.response.links.add({
       rel: 'invalidates',
       href: `/person/${person.id}/sheet/${entryDate.year}/${entryDate.weekNumber}`,
     });
   }
+
 }
 
 export default new Entry();

--- a/src/entry/controller/item.ts
+++ b/src/entry/controller/item.ts
@@ -6,39 +6,28 @@ import * as entryService from '../service';
 import * as personService from '../../person/service';
 import * as projectService from '../../project/service';
 import * as hal from '../formats/hal';
-
-import { Entry as EntrySchema } from '@badgateway/tt-types';
+import {DateTime} from 'luxon';
+import {Entry as EntrySchema} from '@badgateway/tt-types';
 
 class Entry extends Controller {
-
   async get(ctx: Context) {
-
     ctx.response.type = 'application/hal+json';
 
-    const person = await personService.findById(
-      +ctx.params.personId,
-    );
+    const person = await personService.findById(+ctx.params.personId);
 
     ctx.response.body = hal.item(
-      await entryService.findById(
-        person,
-        +ctx.params.entryId,
-      )
+      await entryService.findById(person, +ctx.params.entryId)
     );
   }
 
   async put(ctx: Context) {
-
-    ctx.request.validate<EntrySchema>('https://tt.badgateway.net/schema/entry.json');
-
-    const person = await personService.findById(
-      +ctx.params.personId,
+    ctx.request.validate<EntrySchema>(
+      'https://tt.badgateway.net/schema/entry.json'
     );
 
-    const entry = await entryService.findById(
-      person,
-      +ctx.params.entryId,
-    );
+    const person = await personService.findById(+ctx.params.personId);
+
+    const entry = await entryService.findById(person, +ctx.params.entryId);
 
     const body = ctx.request.body;
 
@@ -48,9 +37,11 @@ class Entry extends Controller {
       throw new BadRequest('A link with rel "project" must be provided');
     }
 
-    const projectId = (projectUrl.href.split('/').pop());
+    const projectId = projectUrl.href.split('/').pop();
     if (!projectId) {
-      throw new BadRequest('The project link must be in the format /projects/123');
+      throw new BadRequest(
+        'The project link must be in the format /projects/123'
+      );
     }
 
     const project = await projectService.findById(+projectId);
@@ -63,29 +54,27 @@ class Entry extends Controller {
 
     await entryService.update(entry);
     ctx.status = 204;
-
   }
 
   async delete(ctx: Context) {
+    const person = await personService.findById(+ctx.params.personId);
 
-    const person = await personService.findById(
-      +ctx.params.personId,
-    );
+    const entry = await entryService.findById(person, +ctx.params.entryId);
 
-    const entry = await entryService.findById(
-      person,
-      +ctx.params.entryId,
-    );
+    const entryDate = DateTime.fromISO(entry.date);
 
     await entryService.deleteEntry(entry);
 
     ctx.response.status = 204;
     ctx.response.links.add({
       rel: 'invalidates',
-      href: `/person/${person.id}/entry`
+      href: `/person/${person.id}/entry`,
+    });
+    ctx.response.links.add({
+      rel: 'invalidates',
+      href: `/person/${person.id}/sheet/${entryDate.year}/${entryDate.weekNumber}`,
     });
   }
-
 }
 
 export default new Entry();


### PR DESCRIPTION
### RE: [Handle deleting single timesheet entries before submit](https://github.com/badgateway/tt-api/issues/35)

## Summary of changes:

- Add `invalidates` link for the `entry` delete controller action thing.
  - Why: when deleting an entry, on the frontend the collection items would still maintain the deleted entity as part of the rendered list. Now, the collection updates on delete and the render is correct.

----
Feedback, nitpicks, and/or corrections encouraged. 🤖